### PR TITLE
Set default reusability for activate_node method and refactor instance variables in BootStrappingTreeger

### DIFF
--- a/crms/treeger.py
+++ b/crms/treeger.py
@@ -408,7 +408,7 @@ class Treeger(ITreeger):
             logger.error(f'Failed to launch node {node_key}: {e}')
             raise
     
-    def activate_node(self, node_key: str, reusibility: ReuseAction) -> str:
+    def activate_node(self, node_key: str, reusibility: ReuseAction = ReuseAction.REPLACE) -> str:
         return self._start_node_service(node_key, reusibility)
     
     def _stop_node_service(self, node_key: str) -> bool:

--- a/icrms/itreeger.py
+++ b/icrms/itreeger.py
@@ -53,7 +53,7 @@ class ITreeger:
     def unmount_node(self, node_key: str) -> bool:
         ...
         
-    def activate_node(self, node_key: str, reusibility: ReuseAction) -> str:
+    def activate_node(self, node_key: str, reusibility: ReuseAction = ReuseAction.REPLACE) -> str:
         ...
         
     def deactivate_node(self, node_key: str) -> bool:


### PR DESCRIPTION
Establish a default value for the `reusibility` parameter in the `activate_node` method and improve the clarity of instance variable names within the `BootStrappingTreeger` class.